### PR TITLE
feat: apply editor tag view

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -22,10 +22,11 @@ const Editor = () => {
       <ReactQuill
         css={editor}
         theme="snow"
-        defaultValue={text}
+        defaultValue={`<xmp>${text}</xmp>`}
         onChange={onChangeText}
         modules={modules}
         formats={formats}
+        preserveWhitespace={true}
       />
     </>
   );


### PR DESCRIPTION
에디터 화면에서 마크업 문법이 포함된 텍스트를 작성시 오른쪽 마크다운 프리뷰에 그대로 적용되어서 보여진다.
그리고 링크 공유를 통해 서버 DB에 저장되고, 해당 링크를 다시 주소창에 입력하면 GET 요청을 통해 해당 링크와 맞는 데이터(텍스트)가 화면에 보여진다.
여기서 문제가 에디터에 적용했던 마크업 문법이 모두 삭제되어 보여지는 것이다.

이 문제를 해결하기 위해 `<xmp>`를 사용했지만, HTML5에서 더 이상 권장되지 않는다. 
대신 `<pre>`를 사용하라고 한다. 하지만 `<pre>`를 사용할 경우 마찬가지로 태그 문법이 보여지지 않는다.
1차적으로 해결했지만 대안이 없는지 다시 찾아보려고 한다.