### PR TITLE
Fix/internal link

### DIFF
--- a/src/components/CustomToolbar.js
+++ b/src/components/CustomToolbar.js
@@ -67,9 +67,6 @@ const CustomToolbar = () => {
 };
 
 const ToolbarWrapper = styled.div`
-  border-bottom: 1px solid #dddddd;
-  padding-bottom: 5px;
-
   button {
     cursor: pointer;
     vertical-align: middle;

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -26,13 +26,13 @@ const Editor = () => {
   const handleKeyDown = (e) => {
     const isMetaKey = e.metaKey || e.ctrlKey;
 
-    if (e.code === 'Enter') {
+    if (e.keyCode === 13) {
       const resultValue = addTypeCurrentPosition(inputText.current, '   ');
 
       dispatch(addText(resultValue));
     }
 
-    if (e.code === 'Tab') {
+    if (e.keyCode === 9) {
       e.preventDefault();
       const resultValue = addTypeCurrentPosition(inputText.current, '  ');
 

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import styled from '@emotion/styled';
 import { useDispatch, useSelector } from 'react-redux';
-import { useRouteMatch, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { nanoid } from 'nanoid';
 
 import { addLinkId, addText, addTextArea, saveText } from '../features/slice';
@@ -12,7 +12,6 @@ import { saveContents } from '../api';
 const Editor = () => {
   const inputText = useRef();
   const dispatch = useDispatch();
-  const { path } = useRouteMatch();
   const { pathname } = useLocation();
   const { text, fullEditor, fullMarkdown } = useSelector((state) => state.contents);
 
@@ -56,7 +55,7 @@ const Editor = () => {
         dispatch(saveText());
         saveContents(id, text);
         setTimeout(() => {
-          window.location.href = `${path}/${id}`;
+          window.location.href = `/d/${id}`;
         }, 700);
       }
 
@@ -65,7 +64,7 @@ const Editor = () => {
         dispatch(saveText());
         saveContents(link, text);
         setTimeout(() => {
-          window.location.href = `${path}/${link}`;
+          window.location.href = `/d/${link}`;
         }, 700);
       }
     }

--- a/src/components/SharingModal.js
+++ b/src/components/SharingModal.js
@@ -4,28 +4,27 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { AiOutlineLink } from 'react-icons/ai';
 import { useSelector } from 'react-redux';
-import { Link, useRouteMatch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 const SharingModal = ({ updateModal }) => {
   const CLIENT_PORT = process.env.REACT_APP_CLIENT_PORT;
   const linkValue = useRef();
   const { linkId } = useSelector((state) => state.contents);
-  const { path } = useRouteMatch();
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(linkValue.current.defaultValue);
   };
 
   return (
-    <Link to={`${path}/${linkId}`} css={link}>
+    <Link to={`/d/${linkId}`} css={link}>
       <ModalWrapper onClick={() => updateModal(false)} />
       <ModalWindow>
         <IconWrapper onClick={handleCopy} >
           <AiOutlineLink fontSize={32} color='#ffffff' />
         </IconWrapper>
         <InputWrapper>
-          <input type='text' value={`http://localhost:${CLIENT_PORT}${path}/${linkId}`} ref={linkValue} readOnly />
+          <input type='text' value={`http://localhost:${CLIENT_PORT}/d/${linkId}`} ref={linkValue} readOnly />
           <button onClick={handleCopy}>복사</button>
         </InputWrapper>
       </ModalWindow>

--- a/src/components/TextScreen.js
+++ b/src/components/TextScreen.js
@@ -10,24 +10,44 @@ import SaveBox from './shared/SaveBox';
 import TextScreenWrapper from './shared/TextScreenWrapper';
 
 const TextScreen = () => {
-  const { isSaved } = useSelector((state) => state.contents);
+  const { isSaved, fullScreen } = useSelector((state) => state.contents);
 
   return (
-    <TextScreenWrapper>
-      {isSaved && <SaveBox />}
-      <Header>
+    <>
+      <Header className={fullScreen ? 'full-screen' : ''}>
         <CustomToolbar />
       </Header>
+    <TextScreenWrapper>
+      {isSaved && <SaveBox />}
       <Main>
         <Editor />
         <MarkdownView />
       </Main>
     </TextScreenWrapper>
+    </>
   );
 };
 
 const Header = styled.div`
+  position: relative;
+  box-sizing: border-box;
   padding: 5px;
+  width: 90%;
+  margin: 0 auto;
+  z-index: 2000;
+  background-color: white;
+  border-radius: 5px 5px 0px 0px;
+  border-bottom: 1px solid #dddddd;
+
+  ${({ className }) => {
+    if (className === 'full-screen') {
+      return `
+        position: fixed;
+        width: 100%;
+        top: 0;
+      `;
+    }
+  }};
 `;
 
 const Main = styled.div`

--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -2,14 +2,23 @@ import React from 'react';
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useRouteMatch } from 'react-router';
 
 import character from '../assets/easyme.png';
 
 const Title = () => {
+  const { url } = useRouteMatch();
+
+  const handleTitle = () => {
+    window.location.href = url;
+  };
+
   return (
     <Wrapper>
-      <img src={character} css={image} alt='easyme' />
-      <div css={title}>EASYME.md</div>
+      <ClickWrapper onClick={handleTitle}>
+        <img src={character} css={image} alt='easyme' />
+        <div css={title}>EASYME.md</div>
+      </ClickWrapper>
     </Wrapper>
   );
 };
@@ -21,6 +30,17 @@ const Wrapper = styled.div`
   align-items: center;
   margin-top: 30px;
   margin-bottom: 30px;
+`;
+
+const ClickWrapper = styled.div`
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+  -ms-user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
 `;
 
 const image = css`
@@ -42,10 +62,6 @@ const title = css`
   color: white;
   font-size: 4rem;
   text-shadow: 4px 6px 10px rgba(33, 40, 56, 0.2);
-  user-select: none;
-  -ms-user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
 `;
 
 export default Title;

--- a/src/components/shared/TextScreenWrapper.js
+++ b/src/components/shared/TextScreenWrapper.js
@@ -22,26 +22,34 @@ const Wrapper = styled.div`
 const ScreenWrapper = styled.div`
   position: relative;
   overflow: hidden;
-  border-radius: 15px;
   height: 70vh;
   background: white;
   border: 1px solid rgba(255, 255, 255, 0.18);
   box-shadow: 4px 4px 12px 0px rgba(0, 0, 0, 0.2);
-  border-radius: 5px;
+  border-radius: 0px 0px 5px 5px;
+  z-index: 1000;
 
   ${({ className }) => {
     if (className === 'full-screen') {
       return `
         position: fixed !important;
-        z-index: 300;
-        top: 0;
-        left: 0;
         width: 100% !important;
         height: 100% !important;
+        z-index: 300;
+        top: 2rem;
+        left: 0;
         background: white;
       `;
     }
   }};
+
+  @media (max-width: 819px) {
+    top: 7%;
+  }
+
+  @media (max-width: 333px) {
+    top: 9%;
+  }
 `;
 
 export default TextScreenWrapper;


### PR DESCRIPTION
- 에디터에서 오른쪽 마크다운 뷰에 헤더로된 텍스트의 링크를 누르면 해당 줄이 위로 올라오게 되는데, Custom Toolbar가 밀리면서 사라지는 현상이 있음.
  - Toolbar와 에디터 영역을 하나의 Wrapper가 아닌 따로 나눠서 해결
- 텍스트를 입력하고 Enter, Tab을 누르면 같은 문자가 한 번 더 입력되는 현상 해결
  - 기존에 event의 code로 조건 처리를 한 것을 keyCode(번호)로 바꿈(나머지도 다 바꿀 예정)
- 메인 타이틀, 이미지를 눌렀을 때 홈(또는 현재 링크)으로 이동(새로고침)하도록 구현