### PR TITLE
Expand SEO title and description to recommended length

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#2E3341" />
 
-    <title>EASYME.md | 리드미, 마크다운 작성 사이트</title>
-    <meta name="description" content="EASYME.md(이지미)는 README(리드미) 작성, Markdown 문법이 익숙하지 않은 사람들을 위해 만든 사이트입니다." />
-    <meta name="keywords" content="easyme, readme, 리드미, 이지미, markdown, markdownsite, 마크다운, 마크다운작성사이트" />
+    <title>EASYME.md | README·마크다운 작성이 쉬워지는 실시간 에디터</title>
+    <meta name="description" content="EASYME.md(이지미)는 README와 Markdown 문법에 익숙하지 않아도 편하게 글을 작성할 수 있는 웹 에디터입니다. 툴바로 서식 적용, 실시간 미리보기, 링크 한 번으로 공유까지 지원합니다." />
+    <meta name="keywords" content="easyme, readme, 리드미, 이지미, markdown, markdownsite, 마크다운, 마크다운작성사이트, 마크다운에디터, 실시간 미리보기" />
     <meta name="robots" content="index, follow" />
     <meta name="google-site-verification" content="sioQswZ6K0vzDLaveDWBachAp5y9pCFuv_2widqDXc4" />
     <meta name="naver-site-verification" content="59a8659d9d6fce0d75c4e70921609fad75cd54fa" />
@@ -18,16 +18,16 @@
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ko_KR" />
     <meta property="og:site_name" content="EASYME.md" />
-    <meta property="og:title" content="EASYME.md | 리드미, 마크다운 작성 사이트" />
-    <meta property="og:description" content="EASYME.md(이지미)는 README(리드미) 작성, Markdown 문법이 익숙하지 않은 사람들을 위해 만든 사이트입니다." />
+    <meta property="og:title" content="EASYME.md | README·마크다운 작성이 쉬워지는 실시간 에디터" />
+    <meta property="og:description" content="EASYME.md(이지미)는 README와 Markdown 문법에 익숙하지 않아도 편하게 글을 작성할 수 있는 웹 에디터입니다. 툴바로 서식 적용, 실시간 미리보기, 링크 한 번으로 공유까지 지원합니다." />
     <meta property="og:url" content="https://www.easy-me.com/" />
     <meta property="og:image" content="https://www.easy-me.com/preview.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="EASYME.md | 리드미, 마크다운 작성 사이트" />
-    <meta name="twitter:description" content="EASYME.md(이지미)는 README(리드미) 작성, Markdown 문법이 익숙하지 않은 사람들을 위해 만든 사이트입니다." />
+    <meta name="twitter:title" content="EASYME.md | README·마크다운 작성이 쉬워지는 실시간 에디터" />
+    <meta name="twitter:description" content="EASYME.md(이지미)는 README와 Markdown 문법에 익숙하지 않아도 편하게 글을 작성할 수 있는 웹 에디터입니다. 툴바로 서식 적용, 실시간 미리보기, 링크 한 번으로 공유까지 지원합니다." />
     <meta name="twitter:image" content="https://www.easy-me.com/preview.png" />
   </head>
   <body>

--- a/src/components/ReactHelmet.js
+++ b/src/components/ReactHelmet.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
 const SITE_URL = 'https://www.easy-me.com';
-const TITLE = 'EASYME.md | 리드미, 마크다운 작성 사이트';
-const DESCRIPTION = 'EASYME.md(이지미)는 README(리드미) 작성, Markdown 문법이 익숙하지 않은 사람들을 위해 만든 사이트입니다.';
+const TITLE = 'EASYME.md | README·마크다운 작성이 쉬워지는 실시간 에디터';
+const DESCRIPTION = 'EASYME.md(이지미)는 README와 Markdown 문법에 익숙하지 않아도 편하게 글을 작성할 수 있는 웹 에디터입니다. 툴바로 서식 적용, 실시간 미리보기, 링크 한 번으로 공유까지 지원합니다.';
 const IMAGE_URL = `${SITE_URL}/preview.png`;
 
 const ReactHelmet = () => {
@@ -15,7 +15,7 @@ const ReactHelmet = () => {
       <meta charSet='utf-8' />
       <meta name='viewport' content='width=device-width, initial-scale=1.0' />
       <meta name='description' content={DESCRIPTION} />
-      <meta name='keywords' content='easyme, readme, 리드미, 이지미, markdown, markdownsite, 마크다운, 마크다운작성사이트' />
+      <meta name='keywords' content='easyme, readme, 리드미, 이지미, markdown, markdownsite, 마크다운, 마크다운작성사이트, 마크다운에디터, 실시간 미리보기' />
       <meta name='robots' content='index, follow' />
       <meta name='google-site-verification' content='sioQswZ6K0vzDLaveDWBachAp5y9pCFuv_2widqDXc4' />
       <meta name='naver-site-verification' content='59a8659d9d6fce0d75c4e70921609fad75cd54fa' />


### PR DESCRIPTION
## Summary

Follow-up to #84. opengraph.xyz flagged two soft issues on the current metadata:

- **Title** 28 chars → recommended 50–60
- **Description** 71 chars → recommended 110–160

Both lengths work but waste the space search engines and social cards will actually show, which costs CTR. Rewrote to cover what the site now does (realtime preview, toolbar formatting, link sharing) and added matching keywords. Applied identically in `public/index.html` and `ReactHelmet` so JS and non-JS crawlers see the same text.

### Before / After

**Title**
- Before: `EASYME.md | 리드미, 마크다운 작성 사이트`
- After: `EASYME.md | README·마크다운 작성이 쉬워지는 실시간 에디터`

**Description**
- Before: `EASYME.md(이지미)는 README(리드미) 작성, Markdown 문법이 익숙하지 않은 사람들을 위해 만든 사이트입니다.`
- After: `EASYME.md(이지미)는 README와 Markdown 문법에 익숙하지 않아도 편하게 글을 작성할 수 있는 웹 에디터입니다. 툴바로 서식 적용, 실시간 미리보기, 링크 한 번으로 공유까지 지원합니다.`

## Test plan

- [ ] After deploy, https://www.opengraph.xyz/url/https%3A%2F%2Fwww.easy-me.com shows no length warnings
- [ ] `view-source:https://www.easy-me.com` has the new title/description in `<head>`
- [ ] Search Console → URL inspection on `/` and `/d` to request a re-crawl

🤖 Generated with [Claude Code](https://claude.com/claude-code)