### PR TITLE
Extend SEO title to recommended 50-60 char range

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#2E3341" />
 
-    <title>EASYME.md | README·마크다운 작성이 쉬워지는 실시간 에디터</title>
+    <title>EASYME.md | 누구나 쉬운 README·리드미 온라인 마크다운 실시간 미리보기 에디터</title>
     <meta name="description" content="EASYME.md(이지미)는 README와 Markdown 문법에 익숙하지 않아도 편하게 글을 작성할 수 있는 웹 에디터입니다. 툴바로 서식 적용, 실시간 미리보기, 링크 한 번으로 공유까지 지원합니다." />
     <meta name="keywords" content="easyme, readme, 리드미, 이지미, markdown, markdownsite, 마크다운, 마크다운작성사이트, 마크다운에디터, 실시간 미리보기" />
     <meta name="robots" content="index, follow" />
@@ -18,7 +18,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ko_KR" />
     <meta property="og:site_name" content="EASYME.md" />
-    <meta property="og:title" content="EASYME.md | README·마크다운 작성이 쉬워지는 실시간 에디터" />
+    <meta property="og:title" content="EASYME.md | 누구나 쉬운 README·리드미 온라인 마크다운 실시간 미리보기 에디터" />
     <meta property="og:description" content="EASYME.md(이지미)는 README와 Markdown 문법에 익숙하지 않아도 편하게 글을 작성할 수 있는 웹 에디터입니다. 툴바로 서식 적용, 실시간 미리보기, 링크 한 번으로 공유까지 지원합니다." />
     <meta property="og:url" content="https://www.easy-me.com/" />
     <meta property="og:image" content="https://www.easy-me.com/preview.png" />
@@ -26,7 +26,7 @@
     <meta property="og:image:height" content="630" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="EASYME.md | README·마크다운 작성이 쉬워지는 실시간 에디터" />
+    <meta name="twitter:title" content="EASYME.md | 누구나 쉬운 README·리드미 온라인 마크다운 실시간 미리보기 에디터" />
     <meta name="twitter:description" content="EASYME.md(이지미)는 README와 Markdown 문법에 익숙하지 않아도 편하게 글을 작성할 수 있는 웹 에디터입니다. 툴바로 서식 적용, 실시간 미리보기, 링크 한 번으로 공유까지 지원합니다." />
     <meta name="twitter:image" content="https://www.easy-me.com/preview.png" />
   </head>

--- a/src/components/ReactHelmet.js
+++ b/src/components/ReactHelmet.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
 const SITE_URL = 'https://www.easy-me.com';
-const TITLE = 'EASYME.md | README·마크다운 작성이 쉬워지는 실시간 에디터';
+const TITLE = 'EASYME.md | 누구나 쉬운 README·리드미 온라인 마크다운 실시간 미리보기 에디터';
 const DESCRIPTION = 'EASYME.md(이지미)는 README와 Markdown 문법에 익숙하지 않아도 편하게 글을 작성할 수 있는 웹 에디터입니다. 툴바로 서식 적용, 실시간 미리보기, 링크 한 번으로 공유까지 지원합니다.';
 const IMAGE_URL = `${SITE_URL}/preview.png`;
 


### PR DESCRIPTION
## Summary

Follow-up to #85. The description came out at the recommended length, but the title was still only 40 chars and opengraph.xyz kept flagging it.

### Before / After

- **Before** (40): `EASYME.md | README·마크다운 작성이 쉬워지는 실시간 에디터`
- **After** (51): `EASYME.md | 누구나 쉬운 README·리드미 온라인 마크다운 실시간 미리보기 에디터`

Added terms people actually search (누구나 쉬운, 리드미, 온라인, 실시간 미리보기) so the longer title also pulls its weight for SEO, not just to silence the warning.

## Test plan

- [ ] After deploy, https://www.opengraph.xyz/url/https%3A%2F%2Fwww.easy-me.com shows no length warnings
- [ ] `view-source:https://www.easy-me.com` has the new title in `<head>` and in the og:/twitter: tags
- [ ] Google search result snippet isn't truncated on the site: operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)